### PR TITLE
Updating request query test cases to only generate one expected failure

### DIFF
--- a/testcases/request/query/missing params.json
+++ b/testcases/request/query/missing params.json
@@ -4,7 +4,7 @@
   "expected" : {
     "method": "GET",
     "path": "/path",
-    "query": "alligator=Mary&hippo=John&elephant=missing",
+    "query": "alligator=Mary&hippo=Fred&elephant=missing",
     "headers": {}
 
   },

--- a/testcases/request/query/unexpected param.json
+++ b/testcases/request/query/unexpected param.json
@@ -11,7 +11,7 @@
   "actual": {
     "method": "GET",
     "path": "/path",
-    "query": "alligator=Mary&hippo=Fred&elephant=unexpected",
+    "query": "alligator=Mary&hippo=John&elephant=unexpected",
     "headers": {}
 
   }


### PR DESCRIPTION
PR to change 2 request query test cases to only have one failure point.

@bethesque Additionally given the change is ok, should testcases/request/query/unexpected param.json still not match?
